### PR TITLE
Update platform to 22.08 for building with GCC 12

### DIFF
--- a/app.organicmaps.desktop.yml
+++ b/app.organicmaps.desktop.yml
@@ -1,6 +1,6 @@
 app-id: app.organicmaps.desktop
 runtime: org.kde.Platform
-runtime-version: '5.15-21.08'
+runtime-version: '5.15-22.08'
 sdk: org.kde.Sdk
 command: OMaps
 rename-desktop-file: OrganicMaps.desktop


### PR DESCRIPTION
* This updates GCC from 11.3.0 to 12.1.0
* Since upstream fixed GCC 12 builds between [a01dfd1 and d5724a9]
  (https://github.com/organicmaps/organicmaps/compare/a01dfd1..d5724a9)
  and those changes are already available in the tagged release `2022.11.24-3`,
  it is time to update.

Signed-off-by: Ferenc Géczi <ferenc.gm@gmail.com>