### PR TITLE
Update beta to actual master

### DIFF
--- a/app.organicmaps.desktop.yml
+++ b/app.organicmaps.desktop.yml
@@ -24,7 +24,7 @@ modules:
       - type: git
         url: https://github.com/organicmaps/organicmaps
         branch: master
-        commit: be5a0aa2991377eedd61f19ec3853332b51b114b
+        commit: ca31bbaee4cd7ffcb6e8483587d244695777daf9
       - type: patch
         path: ./changelog-2023.06.20beta-1.patch
       - type: shell


### PR DESCRIPTION
Maybe it's still makes sense to keep "branch" property for now, so bump to the actual master tip instead.
We can remove the "branch" at any time, if needed.