### PR TITLE
Revert "Add debug info"

### DIFF
--- a/app.organicmaps.desktop.yml
+++ b/app.organicmaps.desktop.yml
@@ -16,7 +16,7 @@ modules:
     buildsystem: cmake-ninja
     builddir: true
     config-opts:
-      - -DCMAKE_BUILD_TYPE=RelWithDebInfo
+      - -DCMAKE_BUILD_TYPE=Release
     cleanup:
       - '/lib' # static libraries and build configs
       - '/include'


### PR DESCRIPTION
This reverts commit 669aec986fec1a0171c9bd4f2c0905d9b59166be.

Because it does not help debugging whatsoever, only degrades user experience.
It is perhaps the `beta` branch where such behaviour belongs not the `stable`.